### PR TITLE
Prevent go back to activation screen

### DIFF
--- a/src/pages/ActivationCode/ActivationCode.tsx
+++ b/src/pages/ActivationCode/ActivationCode.tsx
@@ -47,7 +47,7 @@ export const ActivationCode = ({ navigation }: any) => {
 					AsyncStorage.getItem("token_instalacion")
 						.then((token_ins) => {
 							if (token_ins !== null) {
-								navigation.navigate(ROUTES.HOME);
+								navigation.replace(ROUTES.HOME);
 							} else {
 								setLoading(false);
 							}
@@ -75,7 +75,7 @@ export const ActivationCode = ({ navigation }: any) => {
 							console.log("data", data);
 							AsyncStorage.setItem("token_instalacion", data.token_instalacion)
 								.then(() => {
-									navigation.navigate(ROUTES.HOME);
+									navigation.replace(ROUTES.HOME);
 								})
 								.catch((error) => {
 									dispatch(


### PR DESCRIPTION
After Activation code is entered and validated, Instalation token exists and vigilante can no longer go back.
- Action is prevented on Router and Device button